### PR TITLE
Update example-admin.json

### DIFF
--- a/example-admin.json
+++ b/example-admin.json
@@ -17,7 +17,10 @@
 					{ "name": "email", "title": "E-mail", "type": "email", "exportable": true },
 					{ "name": "note", "title": "Note", "input": "textarea", "exportable": true },
 					{ "name": "active", "title": "Active", "type": "bool", "input": "checkbox", "display_helper": "booleanToYesNo", "exportable": true }
-				]
+				],
+				"roles_allowed_to_insert": ["admin"],
+				"roles_allowed_to_update": ["admin"],
+				"roles_allowed_to_delete": ["admin"]
 			}
 		],
 
@@ -96,6 +99,7 @@
 					"pages": [
 						{
 							"name": "insert",
+							"roles": ["admin"],
 							"components": [
 								{
 									"name": "insert_form",
@@ -135,6 +139,7 @@
 
 						{
 							"name": "edit",
+							"roles": ["admin"],
 							"route_params": ["customerId"],
 							"components": [
 								{
@@ -375,9 +380,7 @@
 						{ "title": "Customers", "route": "customers" }
 					]
 				}
-				]
-			},
-
+			]
 		},
 		"copy_files": [
 			{ "source": "files/loaddata.js", "dest": "SERVER_DIR/loaddata.js" }


### PR DESCRIPTION
- JSON was invalid (extra braces)
- Restricted write operations to admin only

Meteor kitchen doesn't support fine-tune allow/deny rules (yet). So, to make only one field to be updatable to specific user role, you'l need to manually add deny rule (suggest adding deny.js file into "copy_files" and copy it into SERVER_DIR).